### PR TITLE
Fixes mentioned IAM permissions for Kinesis Data Stream

### DIFF
--- a/doc_source/learning-kinesis-module-one-iam.md
+++ b/doc_source/learning-kinesis-module-one-iam.md
@@ -17,7 +17,8 @@ The following are the minimum permissions generally required for a Kinesis Data 
 
 | **Actions** | **Resource** | **Purpose** | 
 | --- | --- | --- | 
-| DescribeStream | Kinesis data stream | Before attempting to read records, the consumer checks if the stream exists and is active, and if the shards are contained in the stream\. | 
+| DescribeStream, DescribeStreamSummary, DescribeStreamConsumer | Kinesis data stream | Before attempting to read records, the consumer checks if the stream exists and is active, and if the shards are contained in the stream\. |
+| SubscribeToShard, RegisterStreamConsumer | Kinesis data stream | Subscribes and register a consumers to a Kinesis Data Stream shard\. |
 | GetRecords, GetShardIterator  | Kinesis data stream | Read records from a Kinesis Data Streams shard\. | 
 | CreateTable, DescribeTable, GetItem, PutItem, Scan, UpdateItem | Amazon DynamoDB table | If the consumer is developed using the Kinesis Client Library \(KCL\), it needs permissions to a DynamoDB table to track the processing state of the application\. The first consumer started creates the table\.  | 
 | DeleteItem | Amazon DynamoDB table | For when the consumer performs split/merge operations on Kinesis Data Streams shards\. | 


### PR DESCRIPTION
*Issue #, if available:

-

*Description of changes:*

Added missing permissions for the KCL according to https://github.com/awslabs/amazon-kinesis-client/blob/a05e22f7820c0b088001ddc9816ab452b80a5539/CHANGELOG.md#release-200-august-02-2018

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
